### PR TITLE
chore: add .prettierrc.json

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,1 @@
+{"requirePragma": true}


### PR DESCRIPTION
This PR:
- Adds a `.prettierrc.json`

For people who use `prettier`, this would be very useful since it disables prettier for some files.
While this doesn't change anything important, I would recommend merging it since it's really annoying that prettier formats everything everytime I try to do something.