### PR TITLE
feat(rankup): rankup-to-number feature

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -345,7 +345,7 @@ Commands.daily = new Command("Get some free DogeCoins, works only once per day",
     }
 }, "Economy")
 
-Commands.rankup = new Command("Increases your rank if you have enough money\nthe rank can be increased multiple times if given an amount of times", (message, args) => {
+Commands.rankup = new Command("Increases your rank if you have enough money\nthe rank can be increased multiple times if given an amount of times\n\nIf the rank number starts with '=', instead of adding the current rank with `amount`, your rank will be exactly `amount`.", (message, args) => {
     let EconomySystem = Economy.getEconomySystem(message.author)
     let oldrank = EconomySystem.rank
     let times = args[0]?.startsWith('=')
@@ -360,7 +360,7 @@ Commands.rankup = new Command("Increases your rank if you have enough money\nthe
     if (oldrank != EconomySystem.rank) {
         message.channel.send(EconomySystem.user + " is now rank " + EconomySystem.rank + "!")
     }
-}, "Economy", [new RequiredArg(0, undefined, "times", true)])
+}, "Economy", [new RequiredArg(0, undefined, "amount", true)])
 
 Commands.gamble = new Command("Gamble your money away cause you have a terrible life", (message, args) => {
     let gamble = parseInt(args[0])

--- a/src/commands.js
+++ b/src/commands.js
@@ -347,8 +347,10 @@ Commands.daily = new Command("Get some free DogeCoins, works only once per day",
 
 Commands.rankup = new Command("Increases your rank if you have enough money\nthe rank can be increased multiple times if given an amount of times", (message, args) => {
     let EconomySystem = Economy.getEconomySystem(message.author)
-    let times = parseInt(args[0]) || 1
     let oldrank = EconomySystem.rank
+    let times = args[0]?.startsWith('=')
+        ? parseInt(args[0].slice(1)) - oldrank || 0
+        : parseInt(args[0]) || 1
     for (let i = 1; i <= times; i++) {
         let needed = 100 * EconomySystem.rank
         if (EconomySystem.buy(needed, message, undefined, EconomySystem.user + " needs " + (needed - EconomySystem.money) + " more DogeCoins for rank " + (EconomySystem.rank + 1))) {

--- a/src/commands.js
+++ b/src/commands.js
@@ -348,6 +348,10 @@ Commands.daily = new Command("Get some free DogeCoins, works only once per day",
 Commands.rankup = new Command("Increases your rank if you have enough money\nthe rank can be increased multiple times if given an amount of times\n\nIf the rank number starts with '=', instead of adding the current rank with `amount`, your rank will be exactly `amount`.", (message, args) => {
     let EconomySystem = Economy.getEconomySystem(message.author)
     let oldrank = EconomySystem.rank
+
+    if (args[0]?.startsWith('=') && ((parseInt(args[0].slice(1)) || 1) <= oldrank))
+        return void message.channel.send(`The rank must be above ${oldrank}!`)
+
     let times = args[0]?.startsWith('=')
         ? parseInt(args[0].slice(1)) - oldrank || 0
         : parseInt(args[0]) || 1


### PR DESCRIPTION
This PR:
- Adds a rankup-to-rank feature.

This can be useful if you want to reach a specific rank without doing the math yourself (e.g. `&rankup =69420`).

Fixes #29