### PR TITLE
feat: internal packages

### DIFF
--- a/lib/evaluate/index.js
+++ b/lib/evaluate/index.js
@@ -1,0 +1,54 @@
+const VM = require('vm');
+
+/**
+ * @typedef {object} EvaluatorOptions
+ * @property {?string[]} EvaluatorOptions.stdlibs
+ * @property {?Record<string, unknown>} EvaluatorOptions.customModules
+ * @property {?number} EvaluatorOptions.timeout
+ */
+
+/**
+ * **Evaluate a JavaScript code using node's `vm` module.**
+ *
+ * @param {string} code - The code string to evaluate.
+ * @param {VM.Context} [globals] - Globals to put. May be used to override other variables.
+ * @param {EvaluatorOptions} config - Configurations for use. Properties may include:
+ * - **`stdlibs`** {`string[]`} - node standard library modules to put.
+ * - **`customModules`** {`{[K: string]: unknown}`} - custom modules to put. these modules
+ *   can be accessed by `require('debug:<module>')`
+ * - **`timeout`** {`number`} - the timout for the vm process.
+ * @returns - The result of the last expression in the code. May be a {@link Promise}.
+ */
+function evaluate(code, globals, config = {}) {
+  const context = {
+    require: new Proxy(require, {
+      apply(target, thisArg, [name]) {
+        if (typeof name != 'string')
+          throw new TypeError("The 'id' argument must be of type string.")
+
+        if (require('module').builtinModules.includes(name)) {
+          if (config?.stdlibs?.includes(name)) {
+            return Reflect.apply(target, thisArg, [name]);
+          } else throw new Error(`module '${name}' is restricted`);
+        } else if (name.startsWith('debug:')) {
+          return config.customModules[name.slice(6).toLowerCase()]
+        } else throw new Error(`module '${name}' does not exist`);
+      },
+      get(target, property, receiver) {
+        if (['cache', 'main'].includes(property))
+          return 'restricted'
+        else return Reflect.get(target, property,receiver)
+      }
+    }),
+    ...globals
+  };
+
+  return new VM.Script(code, {
+    filename: 'evaluate',
+  }).runInNewContext(context, {
+    breakOnSigint: true,
+    timeout: config.timeout ?? 1000
+  });
+}
+
+module.exports = evaluate;

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
   "dependencies": {
     "discord.js": "^13.3.0",
     "dotenv": "^10.0.0"
+  },
+  "imports": {
+    "#*": "./lib/*/index.js"
   }
 }

--- a/src/commands.js
+++ b/src/commands.js
@@ -1,7 +1,7 @@
 
 const Discord = require('discord.js')
-const fs = require('fs');
 const { inspect } = require('util');
+const evaluate = require('#evaluate');
 
 class RequiredArg {
     constructor(argnum, errormsg, name, notrequired) {
@@ -223,8 +223,6 @@ Commands.clown = new Command("Given a person or a thing, the bot will say how mu
             break
     }
 }, "Math", [new RequiredArg(0, "You're a clown at 100%, since you didn't even give me something or someone", "something")])
-
-const { evaluate } = require('./developer');
 
 Commands.eval = new Command("Evaluates the given args as JavaScript code, and returns the output", (message, args) => {
     try {

--- a/src/developer.js
+++ b/src/developer.js
@@ -5,8 +5,8 @@ const { Console } = require("console");
 const { inspect } = require("util");
 const { serialize, deserialize } = require("v8");
 const Stream = require("stream");
-const {Buffer} = require('buffer');
-const VM = require('vm')
+const { Buffer } = require('buffer');
+const evaluate = require('#evaluate')
 const childProcess = require('child_process');
 
 function hasOwnProperty(object, key) {
@@ -124,58 +124,6 @@ new Promise((resolve) => {
 })
 \`\`\`
 `.trim()
-
-/**
- * @typedef {object} EvaluatorOptions
- * @property {?string[]} EvaluatorOptions.stdlibs
- * @property {?Record<string, unknown>} EvaluatorOptions.customModules
- * @property {?number} EvaluatorOptions.timeout
- */
-
-/**
- * **Evaluate a JavaScript code using node's `vm` module.**
- *
- * @param {string} code - The code string to evaluate.
- * @param {VM.Context} [globals] - Globals to put. May be used to override other variables.
- * @param {EvaluatorOptions} config - Configurations for use. Properties may include:
- * - **`stdlibs`** {`string[]`} - node standard library modules to put.
- * - **`customModules`** {`{[K: string]: unknown}`} - custom modules to put. these modules
- *   can be accessed by `require('debug:<module>')`
- * - **`timeout`** {`number`} - the timout for the vm process.
- * @returns - The result of the last expression in the code. May be a {@link Promise}.
- */
-function evaluate(code, globals, config = {}) {
-  const context = {
-    require: new Proxy(require, {
-      apply(target, thisArg, [name]) {
-        if (typeof name != 'string')
-          throw new TypeError("The 'id' argument must be of type string.")
-
-        if (require('module').builtinModules.includes(name)) {
-          if (config?.stdlibs?.includes(name)) {
-            return Reflect.apply(target, thisArg, [name]);
-          } else throw new Error(`module '${name}' is restricted`);
-        } else if (name.startsWith('debug:')) {
-          return config.customModules[name.slice(6).toLowerCase()]
-        } else throw new Error(`module '${name}' does not exist`);
-      },
-      get(target, property, receiver) {
-        if (['cache', 'main'].includes(property))
-          return 'restricted'
-        else return Reflect.get(target, property,receiver)
-      }
-    }),
-    ...globals
-  };
-
-  return new VM.Script(code, {
-    filename: 'evaluate',
-  }).runInNewContext(context, {
-    breakOnSigint: true,
-    timeout: config.timeout ?? 1000
-  });
-}
-module.exports.evaluate = evaluate;
 
 /**
  * @template {Record<string, any>} O


### PR DESCRIPTION
This PR:
- Adds a proof of concept for splitting code into much more manageable chunks.

When you `require("#<name>")`, it will load `/lib/<name>/index.js` instead.
